### PR TITLE
Add release workflows MCP-430

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,26 @@
+name: CodeQL (GitHub Actions)
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze-actions:
+    name: Analyze workflows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: actions
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,66 @@
+name: Draft Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - ".cursor-plugin/plugin.json"
+      - ".claude-plugin/plugin.json"
+      - "gemini-extension.json"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  draft-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository with tags
+        uses: actions/checkout@v6
+
+      - name: Read and validate plugin versions
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_version="$(jq -r '.version' .cursor-plugin/plugin.json)"
+          claude_version="$(jq -r '.version' .claude-plugin/plugin.json)"
+          gemini_version="$(jq -r '.version' gemini-extension.json)"
+
+          if [[ "$release_version" != "$claude_version" || "$release_version" != "$gemini_version" ]]; then
+            echo "Plugin version mismatch detected; refusing to create release." >&2
+            exit 1
+          fi
+
+          echo "release_tag=v$release_version" >> "$GITHUB_OUTPUT"
+
+      - name: Skip when release already exists
+        id: exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "${{ steps.version.outputs.release_tag }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create draft release with generated notes
+        if: ${{ steps.exists.outputs.exists == 'false' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          gh release create "${{ steps.version.outputs.release_tag }}" \
+            --title "${{ steps.version.outputs.release_tag }}" \
+            --target "$GITHUB_SHA" \
+            --draft \
+            --generate-notes

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,107 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_source:
+        description: "How to determine the next version"
+        required: true
+        default: patch
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+          - exact
+      exact_version:
+        description: "Exact version (required when version_source=exact), e.g. 1.2.3"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare-release-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Compute target version
+        id: version
+        shell: bash
+        env:
+          VERSION_SOURCE: ${{ inputs.version_source }}
+          EXACT_VERSION: ${{ inputs.exact_version }}
+        run: |
+          set -euo pipefail
+
+          current_version="$(jq -r '.version' .cursor-plugin/plugin.json)"
+          claude_version="$(jq -r '.version' .claude-plugin/plugin.json)"
+          gemini_version="$(jq -r '.version' gemini-extension.json)"
+
+          if [[ "$current_version" != "$claude_version" || "$current_version" != "$gemini_version" ]]; then
+            echo "Plugin version mismatch detected:" >&2
+            echo "  .cursor-plugin/plugin.json: $current_version" >&2
+            echo "  .claude-plugin/plugin.json: $claude_version" >&2
+            echo "  gemini-extension.json: $gemini_version" >&2
+            exit 1
+          fi
+
+          if [[ "$VERSION_SOURCE" == "exact" ]]; then
+            if [[ -z "${EXACT_VERSION:-}" ]]; then
+              echo "Input exact_version is required when version_source=exact." >&2
+              exit 1
+            fi
+
+            target_version="$(npx --yes semver "$EXACT_VERSION")"
+          else
+            target_version="$(npx --yes semver "$current_version" -i "$VERSION_SOURCE")"
+          fi
+
+          if [[ "$target_version" == "$current_version" ]]; then
+            echo "Target version matches current version ($current_version); nothing to release." >&2
+            exit 1
+          fi
+
+          echo "current_version=$current_version" >> "$GITHUB_OUTPUT"
+          echo "target_version=$target_version" >> "$GITHUB_OUTPUT"
+          echo "branch_name=release/v$target_version" >> "$GITHUB_OUTPUT"
+
+      - name: Update plugin versions
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tmp_file="$(mktemp)"
+          jq '.version = "${{ steps.version.outputs.target_version }}"' .cursor-plugin/plugin.json > "$tmp_file"
+          mv "$tmp_file" .cursor-plugin/plugin.json
+
+          tmp_file="$(mktemp)"
+          jq '.version = "${{ steps.version.outputs.target_version }}"' .claude-plugin/plugin.json > "$tmp_file"
+          mv "$tmp_file" .claude-plugin/plugin.json
+
+          tmp_file="$(mktemp)"
+          jq '.version = "${{ steps.version.outputs.target_version }}"' gemini-extension.json > "$tmp_file"
+          mv "$tmp_file" gemini-extension.json
+
+      - name: Create release pull request
+        uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # 8.1.0
+        with:
+          base: main
+          branch: ${{ steps.version.outputs.branch_name }}
+          title: "chore: prepare release v${{ steps.version.outputs.target_version }}"
+          commit-message: "chore: bump plugin versions to v${{ steps.version.outputs.target_version }}"
+          body: |
+            ## Summary
+            - Bump plugin version from `${{ steps.version.outputs.current_version }}` to `${{ steps.version.outputs.target_version }}`
+
+            ## Next step
+            - Merge this PR to trigger draft release creation.


### PR DESCRIPTION
Adds release workflows as well as codeql workflow that analyzes our GHA workflows.

Release flow is:
1. Trigger draft-release workflow with patch | minor | major argument or an exact version to release.
2. Workflow updates versions and creates a PR.
3. On each push to main, run the draft release workflow that checks if the current version in plugin.json and friends has been released.
4. If not released, creates a draft release and generates release notes.