### PR TITLE
Add local validate script

### DIFF
--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -4,11 +4,13 @@
 # This script handles only the changed-skill check. A separate workflow step
 # validates all skills (see .github/workflows/validate-skills.yml).
 #
-# NOTE: This script mirrors the validation logic in tools/validate-skills.sh
-# (the local version). If you update the validation logic here, update it there
-# too, and vice versa. The two scripts differ only in output format:
-#   - CI script:    uses --emit-annotations and -o markdown for GitHub Actions
-#   - Local script: uses default output for human-readable terminal viewing
+# NOTE: The validator flags used here (e.g. --strict) should stay aligned with
+# tools/validate-skills.sh (the local version). If you change which checks are
+# run or how strictly they're enforced, update both scripts. The scripts otherwise
+# differ by design:
+#   - CI script:    diffs changed skills, uses --emit-annotations and -o markdown
+#   - Local script: accepts an optional path or validates all skills, uses default
+#                   terminal output
 #
 # Usage: validate-skills.sh <base-ref>
 #   base-ref  The base branch name to diff against (e.g. "main").
@@ -58,7 +60,7 @@ for skill in "${changed_skills[@]}"; do
   # 1. Send all output (including ::error commands) to stdout for GitHub Actions
   # 2. Filter out ::error/::warning/::notice lines before writing to the summary
   skill-validator-ent check --strict --emit-annotations -o markdown "skills/$skill/" \
-    | tee >(grep -v '^::' >> "${GITHUB_STEP_SUMMARY:-/dev/null}") || FAILED=1
+    > >(tee >(grep -v '^::' >> "${GITHUB_STEP_SUMMARY:-/dev/null}")) 2>&1 || FAILED=1
 done
 
 if [ $FAILED -ne 0 ]; then

--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -33,9 +33,14 @@ fi
 # Find unique skill directories containing files changed in this PR.
 # The three-dot diff requires fetch-depth: 0 and a properly configured remote,
 # which is always the case on GitHub Actions.
+diff_output="$(git diff --name-only "origin/${BASE_REF}...HEAD" -- skills/)" || {
+  echo "Error: git diff against origin/${BASE_REF} failed."
+  echo "Ensure the base branch has been fetched (fetch-depth: 0 in the workflow)."
+  exit 1
+}
+
 changed_skills=()
-mapfile -t changed_skills < <(git diff --name-only "origin/${BASE_REF}...HEAD" -- skills/ \
-  2>/dev/null \
+mapfile -t changed_skills < <(echo "$diff_output" \
   | cut -d'/' -f2 \
   | sort -u \
   | grep -v '^$')

--- a/.github/scripts/validate-skills.sh
+++ b/.github/scripts/validate-skills.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
-# Validates all skill directories changed in a pull request.
+# Validates skill directories changed in a pull request.
+#
+# This script handles only the changed-skill check. A separate workflow step
+# validates all skills (see .github/workflows/validate-skills.yml).
+#
+# NOTE: This script mirrors the validation logic in tools/validate-skills.sh
+# (the local version). If you update the validation logic here, update it there
+# too, and vice versa. The two scripts differ only in output format:
+#   - CI script:    uses --emit-annotations and -o markdown for GitHub Actions
+#   - Local script: uses default output for human-readable terminal viewing
 #
 # Usage: validate-skills.sh <base-ref>
 #   base-ref  The base branch name to diff against (e.g. "main").
-#             When omitted or when the remote is unavailable, all skills are validated.
 #
 # Exit codes:
-#   0  All validated skills passed.
+#   0  All validated skills passed (or no changed skills found).
 #   1  One or more skills failed validation.
 
 # -e is intentionally omitted: all error paths are handled explicitly,
@@ -15,27 +23,23 @@ set -uo pipefail
 
 BASE_REF="${1:-}"
 
+if [ -z "$BASE_REF" ]; then
+  echo "Usage: validate-skills.sh <base-ref>"
+  exit 1
+fi
+
 # Find unique skill directories containing files changed in this PR.
 # The three-dot diff requires fetch-depth: 0 and a properly configured remote,
-# which is always the case on GitHub Actions but may not be in local act runs.
+# which is always the case on GitHub Actions.
 changed_skills=()
-if [ -n "$BASE_REF" ]; then
-  mapfile -t changed_skills < <(git diff --name-only "origin/${BASE_REF}...HEAD" -- skills/ \
-    2>/dev/null \
-    | cut -d'/' -f2 \
-    | sort -u \
-    | grep -v '^$')
-fi
+mapfile -t changed_skills < <(git diff --name-only "origin/${BASE_REF}...HEAD" -- skills/ \
+  2>/dev/null \
+  | cut -d'/' -f2 \
+  | sort -u \
+  | grep -v '^$')
 
 if [ "${#changed_skills[@]}" -eq 0 ]; then
-  # Fallback: validate all skill directories (e.g. when git remote is unavailable
-  # in local act testing, or when a PR only deletes files with no remaining dirs).
-  echo "Could not determine changed skills from git diff; validating all skills."
-  mapfile -t changed_skills < <(find skills -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort -u)
-fi
-
-if [ "${#changed_skills[@]}" -eq 0 ]; then
-  echo "No skill directories found, skipping validation."
+  echo "No changed skill directories found, skipping validation."
   exit 0
 fi
 
@@ -53,7 +57,7 @@ for skill in "${changed_skills[@]}"; do
   # We use process substitution to:
   # 1. Send all output (including ::error commands) to stdout for GitHub Actions
   # 2. Filter out ::error/::warning/::notice lines before writing to the summary
-  skill-validator check --strict --emit-annotations -o markdown "skills/$skill/" \
+  skill-validator-ent check --strict --emit-annotations -o markdown "skills/$skill/" \
     | tee >(grep -v '^::' >> "${GITHUB_STEP_SUMMARY:-/dev/null}") || FAILED=1
 done
 

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -20,8 +20,17 @@ jobs:
           go-version: stable
           cache: false
 
-      - name: Install skill-validator
-        run: go install github.com/agent-ecosystem/skill-validator/cmd/skill-validator@latest
+      - name: Install skill-validator-ent
+        run: go install github.com/agent-ecosystem/skill-validator-ent/cmd/skill-validator-ent@latest
 
       - name: Validate changed skills
-        run: bash .github/scripts/validate-skills.sh "${{ github.base_ref }}"
+        run: |
+          echo "## Changed Skills" >> "$GITHUB_STEP_SUMMARY"
+          bash .github/scripts/validate-skills.sh "${{ github.base_ref }}"
+
+      - name: Validate all skills
+        continue-on-error: true
+        run: |
+          echo "## All Skills" >> "$GITHUB_STEP_SUMMARY"
+          skill-validator-ent check --strict --emit-annotations -o markdown skills/ \
+            | tee >(grep -v '^::' >> "$GITHUB_STEP_SUMMARY")

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -24,9 +24,11 @@ jobs:
         run: go install github.com/agent-ecosystem/skill-validator-ent/cmd/skill-validator-ent@latest
 
       - name: Validate changed skills
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           echo "## Changed Skills" >> "$GITHUB_STEP_SUMMARY"
-          bash .github/scripts/validate-skills.sh "${{ github.base_ref }}"
+          bash .github/scripts/validate-skills.sh "$BASE_REF"
 
       - name: Validate all skills
         run: |

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -29,7 +29,6 @@ jobs:
           bash .github/scripts/validate-skills.sh "${{ github.base_ref }}"
 
       - name: Validate all skills
-        continue-on-error: true
         run: |
           echo "## All Skills" >> "$GITHUB_STEP_SUMMARY"
           skill-validator-ent check --strict --emit-annotations -o markdown skills/ \

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -34,4 +34,4 @@ jobs:
         run: |
           echo "## All Skills" >> "$GITHUB_STEP_SUMMARY"
           skill-validator-ent check --strict --emit-annotations -o markdown skills/ \
-            | tee >(grep -v '^::' >> "$GITHUB_STEP_SUMMARY")
+            2>&1 | tee >(grep -v '^::' >> "$GITHUB_STEP_SUMMARY")

--- a/tools/validate-skills.sh
+++ b/tools/validate-skills.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
 # Validates skill directories locally with human-readable output.
 #
-# NOTE: This script mirrors the validation logic in .github/scripts/validate-skills.sh
-# (the CI version). If you update the validation logic here, update it there too,
-# and vice versa. The two scripts differ only in output format:
-#   - CI script:    uses --emit-annotations and -o markdown for GitHub Actions
-#   - Local script: uses default output for human-readable terminal viewing
+# NOTE: The validator flags used here (e.g. --strict) should stay aligned with
+# .github/scripts/validate-skills.sh (the CI version). If you change which checks
+# are run or how strictly they're enforced, update both scripts. The scripts
+# otherwise differ by design:
+#   - CI script:    diffs changed skills, uses --emit-annotations and -o markdown
+#   - Local script: accepts an optional path or validates all skills, uses default
+#                   terminal output
 #
 # Usage: validate-skills.sh [path/to/skill/]
 #   path  Optional path to a single skill directory to validate.
@@ -15,9 +17,9 @@
 #   0  All validated skills passed.
 #   1  One or more skills failed validation.
 
-set -uo pipefail
+set -euo pipefail
 
-# Resolve and cd to the repo root so relative paths (e.g. find skills/) always work,
+# Resolve and cd to the repo root so relative paths always work,
 # regardless of where the script is invoked from.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
   echo "Error: not inside a git repository."
@@ -25,43 +27,19 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 }
 cd "$REPO_ROOT"
 
-SKILL_PATH="${1:-}"
+SKILL_PATH="${1:-skills/}"
 
-skills_to_validate=()
-
-if [ -n "$SKILL_PATH" ]; then
-  # Normalize absolute paths to be relative to the repo root.
-  if [[ "$SKILL_PATH" == /* ]]; then
-    SKILL_PATH="${SKILL_PATH#"$REPO_ROOT"/}"
-  fi
-
-  if [ ! -d "$SKILL_PATH" ]; then
-    echo "Error: '$SKILL_PATH' is not a directory."
-    exit 1
-  fi
-  skills_to_validate+=("$SKILL_PATH")
-else
-  # Validate all skill directories.
-  mapfile -t skills_to_validate < <(find skills -mindepth 1 -maxdepth 1 -type d | sort)
-
-  if [ "${#skills_to_validate[@]}" -eq 0 ]; then
-    echo "No skill directories found under skills/."
-    exit 0
-  fi
+# Normalize absolute paths to be relative to the repo root.
+if [[ "$SKILL_PATH" == /* ]]; then
+  SKILL_PATH="${SKILL_PATH#"$REPO_ROOT"/}"
 fi
 
-FAILED=0
-for skill_dir in "${skills_to_validate[@]}"; do
-  # Ensure the path ends with a trailing slash for consistency with the validator.
-  [[ "$skill_dir" != */ ]] && skill_dir="$skill_dir/"
-
-  echo "Validating: $skill_dir"
-  skill-validator-ent check --strict "$skill_dir" || FAILED=1
-  echo ""
-done
-
-if [ $FAILED -ne 0 ]; then
-  echo "Skill validation failed."
+if [ ! -d "$SKILL_PATH" ]; then
+  echo "Error: '$SKILL_PATH' is not a directory."
+  exit 1
 fi
 
-exit $FAILED
+# Ensure the path ends with a trailing slash for consistency with the validator.
+[[ "$SKILL_PATH" != */ ]] && SKILL_PATH="$SKILL_PATH/"
+
+skill-validator-ent check --strict "$SKILL_PATH"

--- a/tools/validate-skills.sh
+++ b/tools/validate-skills.sh
@@ -19,6 +19,18 @@
 
 set -euo pipefail
 
+if ! command -v skill-validator-ent &>/dev/null; then
+  echo "Error: skill-validator-ent is not installed."
+  echo ""
+  echo "Install via Homebrew (recommended):"
+  echo "  brew tap agent-ecosystem/homebrew-tap"
+  echo "  brew install skill-validator-ent"
+  echo ""
+  echo "Or from source (requires Go 1.25.5+):"
+  echo "  go install github.com/agent-ecosystem/skill-validator-ent/cmd/skill-validator-ent@latest"
+  exit 1
+fi
+
 # Resolve and cd to the repo root so relative paths always work,
 # regardless of where the script is invoked from.
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {

--- a/tools/validate-skills.sh
+++ b/tools/validate-skills.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Validates skill directories locally with human-readable output.
+#
+# NOTE: This script mirrors the validation logic in .github/scripts/validate-skills.sh
+# (the CI version). If you update the validation logic here, update it there too,
+# and vice versa. The two scripts differ only in output format:
+#   - CI script:    uses --emit-annotations and -o markdown for GitHub Actions
+#   - Local script: uses default output for human-readable terminal viewing
+#
+# Usage: validate-skills.sh [path/to/skill/]
+#   path  Optional path to a single skill directory to validate.
+#         When omitted, all directories under skills/ are validated.
+#
+# Exit codes:
+#   0  All validated skills passed.
+#   1  One or more skills failed validation.
+
+set -uo pipefail
+
+# Resolve and cd to the repo root so relative paths (e.g. find skills/) always work,
+# regardless of where the script is invoked from.
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: not inside a git repository."
+  exit 1
+}
+cd "$REPO_ROOT"
+
+SKILL_PATH="${1:-}"
+
+skills_to_validate=()
+
+if [ -n "$SKILL_PATH" ]; then
+  # Normalize absolute paths to be relative to the repo root.
+  if [[ "$SKILL_PATH" == /* ]]; then
+    SKILL_PATH="${SKILL_PATH#"$REPO_ROOT"/}"
+  fi
+
+  if [ ! -d "$SKILL_PATH" ]; then
+    echo "Error: '$SKILL_PATH' is not a directory."
+    exit 1
+  fi
+  skills_to_validate+=("$SKILL_PATH")
+else
+  # Validate all skill directories.
+  mapfile -t skills_to_validate < <(find skills -mindepth 1 -maxdepth 1 -type d | sort)
+
+  if [ "${#skills_to_validate[@]}" -eq 0 ]; then
+    echo "No skill directories found under skills/."
+    exit 0
+  fi
+fi
+
+FAILED=0
+for skill_dir in "${skills_to_validate[@]}"; do
+  # Ensure the path ends with a trailing slash for consistency with the validator.
+  [[ "$skill_dir" != */ ]] && skill_dir="$skill_dir/"
+
+  echo "Validating: $skill_dir"
+  skill-validator-ent check --strict "$skill_dir" || FAILED=1
+  echo ""
+done
+
+if [ $FAILED -ne 0 ]; then
+  echo "Skill validation failed."
+fi
+
+exit $FAILED


### PR DESCRIPTION
Per discussion:
- Add a local script that runs the `skill-validator-ent` tool with the the same `--strict` flag as CI for fast local iteration, but with human-readable-friendly versions of the other flags
- Add a new step to the CI workflow that runs the validator on _all_ skills as an overall health check. This compromise lets a contributor see their own skill as a pass/fail separately from the all skill check, so failures in merged skills can get flagged to the maintaining team proactively.
- Update both CI and the local script to use the `skill-validator-ent` version of the tool, which is the same version used in the `review-skill` skill, so contributors running the script locally don't need a separate base install of `skill-validator` just for this script