### PR TITLE
Remove env variables from the config

### DIFF
--- a/mcp.json
+++ b/mcp.json
@@ -2,12 +2,7 @@
   "mcpServers": {
     "mongodb": {
       "command": "npx",
-      "args": ["-y", "mongodb-mcp-server"],
-      "env": {
-        "MDB_MCP_CONNECTION_STRING": "${MDB_MCP_CONNECTION_STRING}",
-        "MDB_MCP_API_CLIENT_ID": "${MDB_MCP_API_CLIENT_ID}",
-        "MDB_MCP_API_CLIENT_SECRET": "${MDB_MCP_API_CLIENT_SECRET}"
-      }
+      "args": ["-y", "mongodb-mcp-server"]
     }
   }
 }


### PR DESCRIPTION
The env variables were problematic for Claude as it failed to start the server when they were undefined. Since we're just piping them, having them in the config didn't add much value.