### PR TITLE
DOCSP-58329: update docs links

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "email": "agent-plugins@mongodb.com",
     "url": "https://www.mongodb.com"
   },
-  "homepage": "https://www.mongodb.com/docs/mcp-server/overview/",
+  "homepage": "https://www.mongodb.com/docs/claude/",
   "repository": "https://github.com/mongodb/agent-skills",
   "license": "Apache-2.0",
   "keywords": [

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ Collection of official MongoDB agent skills for use in agentic workflows. For mo
 
 ### Claude
 
-First, add this plugin marketplace to Claude: `claude plugin marketplace add https://github.com/mongodb/agent-skills.git`. Then use the `/plugin` command to look for the `mongodb` plugin.
+1. Add the plugin marketplace to Claude locally:
+
+   ```bash
+   claude plugin marketplace add https://github.com/mongodb/agent-skills.git
+   ```
+
+2. Use the `/plugin` command to look for the `mongodb` plugin.
+3. Install the plugin, then run `/reload-plugins` to activate it.
 
 ### Cursor
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MongoDB Agent Skills
 
-Collection of official MongoDB agent skills for use in agentic workflows.
+Collection of official MongoDB agent skills for use in agentic workflows. For more information, refer to the [MongoDB Agent Skills documentation](https://www.mongodb.com/docs/agent-skills/).
 
 ## Installation
 


### PR DESCRIPTION
Update / add docs links. 
> NOTE: Cursor link was already correct; Gemini doesn't have any URL parameter to update. 