### PR TITLE
chore(schema-design): add schema versioning eval MCP-467

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 # User-specific Claude settings
 .claude/settings.local.json
 .score_cache/
+
+.DS_Store

--- a/testing/mongodb-schema-design/evals/evals.json
+++ b/testing/mongodb-schema-design/evals/evals.json
@@ -1,0 +1,28 @@
+{
+  "skill_name": "mongodb-schema-design",
+  "evals": [
+    {
+      "id": 1,
+      "name": "schema-versioning-migration",
+      "prompt": "We have a 'contacts' collection with 8 million documents. Over 2 years, the schema has drifted, some documents have 'phone' as a string, others have it as an object with 'country' and 'number' fields. Some have a 'fullName' string, others have separate 'firstName' and 'lastName'. We need to standardize without downtime. How should we approach this?",
+      "expected_output": "Recommends the Schema Versioning pattern: add a schema_version field, define the target schema, and migrate using one of three strategies — background batch migration, aggregation pipeline update, or lazy read-time migration. Includes a decision tree for when each strategy is appropriate and adds schema validation with moderate/warn first.",
+      "expectations": [
+        "Recommends adding a schema_version field to track which version each document conforms to",
+        "Proposes at least two distinct migration strategies (e.g., background batch, aggregation pipeline update with $set, or lazy read-time migration) with tradeoffs for each",
+        "Suggests using schema validation with validationLevel 'moderate' and validationAction 'warn' initially to discover violations without breaking existing documents",
+        "Provides a way to discover existing schema drift (e.g., aggregation to find unique field structures, or $nor query against the target validator)",
+        "Explains that backward-compatible changes (new optional fields) don't require a version bump, but breaking changes (rename, type change) do"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "negative-test-query-writing",
+      "prompt": "How do I write a MongoDB query to find all users who signed up in the last 30 days and have at least 5 orders? I have a 'users' collection with a 'createdAt' field and an 'orderCount' field.",
+      "expected_output": "This is a straightforward query-writing question, not a schema design question. The response should provide the query without invoking schema design patterns, anti-patterns, or restructuring recommendations.",
+      "expectations": [
+        "Provides a working MongoDB query (find or aggregation) that filters by createdAt and orderCount",
+        "Does NOT recommend restructuring the schema, changing the data model, or applying schema design patterns"
+      ]
+    }
+  ]
+}

--- a/testing/mongodb-schema-design/evals/evals.json
+++ b/testing/mongodb-schema-design/evals/evals.json
@@ -13,16 +13,6 @@
         "Provides a way to discover existing schema drift (e.g., aggregation to find unique field structures, or $nor query against the target validator)",
         "Explains that backward-compatible changes (new optional fields) don't require a version bump, but breaking changes (rename, type change) do"
       ]
-    },
-    {
-      "id": 2,
-      "name": "negative-test-query-writing",
-      "prompt": "How do I write a MongoDB query to find all users who signed up in the last 30 days and have at least 5 orders? I have a 'users' collection with a 'createdAt' field and an 'orderCount' field.",
-      "expected_output": "This is a straightforward query-writing question, not a schema design question. The response should provide the query without invoking schema design patterns, anti-patterns, or restructuring recommendations.",
-      "expectations": [
-        "Provides a working MongoDB query (find or aggregation) that filters by createdAt and orderCount",
-        "Does NOT recommend restructuring the schema, changing the data model, or applying schema design patterns"
-      ]
     }
   ]
 }


### PR DESCRIPTION
MCP-467

We're in the process of adding evals for the mongodb-schema-design skill. This is the first that is testing an existing schema, and uses the pattern-schema-versioning reference. More evals will be added in subsequent prs. 

I've run this a few separate times, on a run of 10 it passed 10/10 with the skill and 3/10 without (counted 2 partials as 0.5 each). That's using an LLM as a judge. I've only read through a few of the results but it seems to make sense. Once we have more of the evals I'll do a more comprehensive analysis. 