### PR TITLE
feat(natural-language-querying): reduce Compass specific instructions and context size MCP-475

### DIFF
--- a/skills/mongodb-natural-language-querying/SKILL.md
+++ b/skills/mongodb-natural-language-querying/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: mcp__mongodb__*
 
 # MongoDB Natural Language Querying
 
-You are an expert MongoDB read-only query generator. When a user requests a MongoDB query or aggregation pipeline, follow these guidelines based on the Compass query generation patterns.
+You are an expert MongoDB read-only query and aggregation pipeline generator.
 
 ## Query Generation Process
 
@@ -15,7 +15,6 @@ You are an expert MongoDB read-only query generator. When a user requests a Mong
 **Required Information:**
 - Database name and collection name (use `mcp__mongodb__list-databases` and `mcp__mongodb__list-collections` if not provided)
 - User's natural language description of the query
-- Current date context: ${currentDate} (for date-relative queries)
 
 **Fetch in this order:**
 
@@ -70,36 +69,24 @@ Prefer find queries over aggregation pipelines because find queries are simpler 
 
 ### 4. Format Your Response
 
-Always output queries in a JSON response structure with stringified MongoDB query syntax. The outer response must be valid JSON, while the query strings inside use MongoDB shell/Extended JSON syntax (with unquoted keys and single quotes) for readability and compatibility with MongoDB tools.
+Output queries in the workspace's language. When there is
+not a language or expected format supplied, always use MongoDB shell syntax (with unquoted keys and single quotes) for readability and compatibility with MongoDB tools.
 
 **Find Query Response:**
-```json
-{
-  "query": {
-    "filter": "{ age: { $gte: 25 } }",
-    "project": "{ name: 1, age: 1, _id: 0 }",
-    "sort": "{ age: -1 }",
-    "limit": "10"
-  }
-}
+```js
+db.collection.find(
+  { age: { $gte: 25 } },
+  { name: 1, age: 1, _id: 0 }
+).sort({ age: -1 }).limit(10)
 ```
 
 **Aggregation Pipeline Response:**
-```json
-{
-  "aggregation": {
-    "pipeline": "[{ $match: { status: 'active' } }, { $group: { _id: '$category', total: { $sum: '$amount' } } }]"
-  }
-}
+```js
+db.collection.aggregate([
+  { $match: { status: 'active' } },
+  { $group: { _id: '$category', total: { $sum: '$amount' } } }
+])
 ```
-
-Note the stringified format:
-- ✅ `"{ age: { $gte: 25 } }"` (string)
-- ❌ `{ age: { $gte: 25 } }` (object)
-
-For aggregation pipelines:
-- ✅ `"[{ $match: { status: 'active' } }]"` (string)
-- ❌ `[{ $match: { status: 'active' } }]` (array)
 
 ## Best Practices
 
@@ -122,11 +109,11 @@ For aggregation pipelines:
    - `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte` for comparisons
    - `$in`, `$nin` for matching against a list of possible values (equivalent to multiple $eq/$ne conditions OR'ed together)
    - `$and`, `$or`, `$not`, `$nor` for logical operations
-   - `$regex` for case sensitive text pattern matching (prefer left-anchored patterns like `/^prefix/` when possible, as they can use indexes efficiently)
+   - `$regex` for case-sensitive text pattern matching (prefer left-anchored patterns like `/^prefix/` when possible, as they can use indexes efficiently)
    - `$exists` for field existence checks (prefer `a: {$ne: null}` to `a: {$exists: true}` to leverage available indexes)
    - `$type` for type matching
 6. **Optimize array field checks** - Use efficient patterns for array operations:
-   - To check if array is non-empty: use `"arrayField.0": {$exists: true}` instead of `arrayField: {$exists: true, $type: "array", $ne: []}`
+   - To check if an array is non-empty: use `"arrayField.0": {$exists: true}` instead of `arrayField: {$exists: true, $type: "array", $ne: []}`
    - Checking for the first element's existence is simpler, more readable, and more efficient than combining existence, type, and inequality checks
    - For matching array elements with multiple conditions, use `$elemMatch`
    - For array length checks, use `$size` when you need an exact count
@@ -187,20 +174,15 @@ If you cannot generate a query:
 5. Suggest creating an index if no appropriate index exists for the query filters
 
 **Generated Query:**
-```json
-{
-  "query": {
-    "filter": "{ status: 'active', age: { $gt: 25 } }",
-    "sort": "{ registrationDate: -1 }"
-  }
-}
+```js
+db.users.find(
+  { status: 'active', age: { $gt: 25 } },
+  { name: 1, age: 1, registrationDate: 1, _id: 0 }
+).sort({ registrationDate: -1 })
 ```
 
-## Size Limits
+## Managing Context Size
 
-Keep requests under 5MB:
-- If sample documents are too large, use fewer samples (minimum 1)
-- Limit to 4 sample documents by default
+Fetching large or numerous sample documents wastes context and can degrade query quality.
+- When sample documents are large, use fewer samples (minimum 1)
 - For very large documents, project only essential fields when sampling
-
----

--- a/skills/mongodb-natural-language-querying/SKILL.md
+++ b/skills/mongodb-natural-language-querying/SKILL.md
@@ -181,5 +181,12 @@ If you cannot generate a query:
 ## Managing Context Size
 
 Fetching large or numerous sample documents wastes context and can degrade query quality.
-- When sample documents are large, use fewer samples (minimum 1)
-- For very large documents, project only essential fields when sampling
+
+**Adjust sample count by schema width:**
+- < 30 fields: `limit: 4` (default)
+- 30–80 fields: `limit: 2`
+- 80–150 fields: `limit: 1`
+- 150+ fields: `limit: 1` with a projection of only the fields relevant to the user's query
+
+**Preview large array fields and strings:**
+- If schema documents contains arrays, use `$slice: 3` in the sample projection to cap array size. Limit string fields to 100 characters with `$substr` in the sample projection to prevent excessively long values from consuming context.

--- a/skills/mongodb-natural-language-querying/SKILL.md
+++ b/skills/mongodb-natural-language-querying/SKILL.md
@@ -63,19 +63,24 @@ Prefer find queries over aggregation pipelines because find queries are simpler 
 Output queries using the user-requested language or driver syntax; if no language or expected format is supplied, always use MongoDB shell syntax (with unquoted keys and single quotes) for readability and compatibility with MongoDB tools.
 
 **Find Query Response:**
-```js
-db.collection.find(
-  { age: { $gte: 25 } },
-  { name: 1, age: 1, _id: 0 }
-).sort({ age: -1 }).limit(10)
+```json
+{
+  "query": {
+    "filter": "{ age: { $gte: 25 } }",
+    "projection": "{ name: 1, age: 1, _id: 0 }",
+    "sort": "{ age: -1 }",
+    "limit": "10"
+  }
+}
 ```
 
 **Aggregation Pipeline Response:**
-```js
-db.collection.aggregate([
-  { $match: { status: 'active' } },
-  { $group: { _id: '$category', total: { $sum: '$amount' } } }
-])
+```json
+{
+  "aggregation": {
+    "pipeline": "[{ $match: { status: 'active' } }, { $group: { _id: '$category', total: { $sum: '$amount' } } }]"
+  }
+}
 ```
 
 ## Best Practices
@@ -164,11 +169,13 @@ If you cannot generate a query:
 5. Suggest creating an index if no appropriate index exists for the query filters
 
 **Generated Query:**
-```js
-db.users.find(
-  { status: 'active', age: { $gt: 25 } },
-  { name: 1, age: 1, registrationDate: 1, _id: 0 }
-).sort({ registrationDate: -1 })
+```json
+{
+  "query": {
+    "filter": "{ status: 'active', age: { $gt: 25 } }",
+    "sort": "{ registrationDate: -1 }"
+  }
+}
 ```
 
 ## Managing Context Size

--- a/skills/mongodb-natural-language-querying/SKILL.md
+++ b/skills/mongodb-natural-language-querying/SKILL.md
@@ -69,8 +69,7 @@ Prefer find queries over aggregation pipelines because find queries are simpler 
 
 ### 4. Format Your Response
 
-Output queries in the workspace's language. When there is
-not a language or expected format supplied, always use MongoDB shell syntax (with unquoted keys and single quotes) for readability and compatibility with MongoDB tools.
+Output queries using the user-requested language or driver syntax; if no language or expected format is supplied, always use MongoDB shell syntax (with unquoted keys and single quotes) for readability and compatibility with MongoDB tools.
 
 **Find Query Response:**
 ```js

--- a/skills/mongodb-natural-language-querying/SKILL.md
+++ b/skills/mongodb-natural-language-querying/SKILL.md
@@ -47,19 +47,10 @@ Also review the available indexes to understand which query patterns will perfor
 
 Prefer find queries over aggregation pipelines because find queries are simpler and easier for other developers to understand.
 
-**For Find Queries**, generate responses with these fields:
-- `filter` - The query filter (required)
-- `project` - Field projection (optional)
-- `sort` - Sort specification (optional)
-- `skip` - Number of documents to skip (optional)
-- `limit` - Number of documents to return (optional)
-- `collation` - Collation specification (optional)
-
 **Use Find Query when:**
 - Simple filtering on one or more fields
-- Basic sorting and limiting
-
-**For Aggregation Pipelines**, generate an array of stage objects.
+- Basic sorting, limiting, or projecting specific fields
+- No need for grouping, complex transformations, or multi-stage processing
 
 **Use Aggregation Pipeline when the request requires:**
 - Grouping or aggregation functions (sum, count, average, etc.)

--- a/testing/mongodb-natural-language-querying/evals/evals.json
+++ b/testing/mongodb-natural-language-querying/evals/evals.json
@@ -47,14 +47,14 @@
       "id": 7,
       "name": "relative-date-find-last-year",
       "prompt": "find all of the movies from last year",
-      "expected_output": "Find query with date filter for 2025 (current year - 1)",
+      "expected_output": "Find query with date filter for 2025 (current year - 1, or uses $$NOW to calculate dynamically)",
       "files": []
     },
     {
       "id": 8,
       "name": "relative-date-find-30-years-ago",
       "prompt": "Which comments were posted 30 years ago. consider all comments from that year. return name and date",
-      "expected_output": "Find query with date range for 1996 (30 years before 2026), project name and date",
+      "expected_output": "Find query with date range for 1996 (30 years before 2026, or uses $$NOW to calculate dynamically), project name and date",
       "files": []
     },
     {
@@ -102,21 +102,21 @@
     {
       "id": 15,
       "name": "basic-aggregate",
-      "prompt": "find all the movies released in 1983",
+      "prompt": "aggregate all the movies released in 1983",
       "expected_output": "Aggregation pipeline with $match on year 1983 (or preferably suggests find query)",
       "files": []
     },
     {
       "id": 16,
       "name": "agg-filter-and-projection",
-      "prompt": "find all the violations for the violation code 21 and only return the car plate",
+      "prompt": "match all the violations for the violation code 21 and only return the car plate",
       "expected_output": "Aggregation with $match on violation_code, $project for plate",
       "files": []
     },
     {
       "id": 17,
       "name": "geo-based-agg",
-      "prompt": "find all the bars 10km from the berlin center, only return their names. Berlin center is at longitude 13.4050 and latitude 52.5200. use correct key for coordinates.",
+      "prompt": "give me an aggregation to find all the bars 10km from the berlin center, only return their names. Berlin center is at longitude 13.4050 and latitude 52.5200. use correct key for coordinates.",
       "expected_output": "Aggregation with $geoNear or $match with geospatial query, coordinates in correct order [13.4050, 52.5200]",
       "files": []
     },
@@ -124,7 +124,7 @@
       "id": 18,
       "name": "agg-nested-fields-match",
       "prompt": "Return all the properties of type \"Hotel\" and with ratings lte 70",
-      "expected_output": "Aggregation with $match on nested property_type and ratings fields",
+      "expected_output": "Aggregation with $match on nested property_type and ratings fields. Or a find with the fields",
       "files": []
     },
     {
@@ -144,42 +144,42 @@
     {
       "id": 21,
       "name": "relative-date-agg-30-years",
-      "prompt": "Which movies were released 30 years ago (consider whole year). return title and year",
-      "expected_output": "Aggregation with $match for year 1996, $project title and year",
+      "prompt": "Which movies were released 30 years ago (consider whole year). return title and year. as an aggregation",
+      "expected_output": "Aggregation with $match for year 1996 (or uses $$NOW to calculate dynamically), $project title and year",
       "files": []
     },
     {
       "id": 22,
       "name": "relative-date-agg-last-year",
-      "prompt": "find all of the movies from last year",
-      "expected_output": "Aggregation with $match for 2025",
+      "prompt": "$match all of the movies from last year",
+      "expected_output": "Aggregation with $match for 2025, or uses $$NOW to calculate last year dynamically",
       "files": []
     },
     {
       "id": 23,
       "name": "agg-array-slice",
       "prompt": "give me just the price and the first 3 amenities (in a field called amenities) of the listing that has \"Step-free access\" in its amenities.",
-      "expected_output": "Aggregation with $match on amenities array, $project with $slice",
+      "expected_output": "Aggregation with $match on amenities array, $project with $slice. Or as a find with array filter and projection with $slice",
       "files": []
     },
     {
       "id": 24,
       "name": "agg-multiple-conditions-match",
-      "prompt": "Return only the Plate IDs of Acura vehicles registered in New York",
+      "prompt": "Write an aggrgation returning only the Plate IDs of Acura vehicles registered in New York",
       "expected_output": "Aggregation with $match for vehicle make and state, $project plate_id",
       "files": []
     },
     {
       "id": 25,
       "name": "agg-non-english",
-      "prompt": "¿Qué alojamiento tiene el precio más bajo? devolver el número en un campo llamado \"precio\"",
+      "prompt": "¿Qué alojamiento tiene el precio más bajo? devolver el número en un campo llamado \"precio\". agregación",
       "expected_output": "Aggregation with $sort by price, $limit 1, $project to rename field",
       "files": []
     },
     {
       "id": 26,
       "name": "agg-simple-sort-limit",
-      "prompt": "give me only cancellation policy and listing url of the most expensive listing",
+      "prompt": "give me only cancellation policy and listing url of the most expensive listing with the $sort stage",
       "expected_output": "Aggregation with $sort descending, $limit 1, $project specific fields",
       "files": []
     },
@@ -237,6 +237,20 @@
       "name": "no-redundant-exists-with-comparison",
       "prompt": "find all documents where age exists and is greater than 20",
       "expected_output": "Find query with ONLY { age: { $gt: 20 } }, should NOT include $exists operator since comparison already implies existence",
+      "files": []
+    },
+    {
+      "id": 35,
+      "name": "max-time-ms-option-used",
+      "prompt": "how do I write a find for where age exists and is greater than 20? I want it to have a maximum time of 5 seconds",
+      "expected_output": "Find query with ONLY { age: { $gt: 20 } }, should NOT include $exists operator since comparison already implies existence, with maxTimeMS option set to 5000",
+      "files": []
+    },
+    {
+      "id": 36,
+      "name": "find-in-java",
+      "prompt": "how do I write a find in java for properties of type \"Hotel\" and with ratings lte 70",
+      "expected_output": "Find query in Java using MongoDB driver with Filters for property_type and ratings",
       "files": []
     }
   ]


### PR DESCRIPTION
 MCP-475

This skill was adapted from Compass' natural language prompts. As a result, it contains instructions specific to how the LLM output is used in Compass. This pr should improve the skill's quality by reducing instruction ambiguity, reducing the size of the required context overall, and removing the Compass specific expected output format to allow for more generalized agentic uses. There are likely more improvements to do here, this is mostly aimed at low hanging fruit. 

This pr also updates the evals to reduce ambiguity. They were also adopted from Compass and expected to be run against either an explicit aggregation or find generator, not one that does both. Added a test for Java and a test that checks that a find with a maxTimeMS can be created.

The evals run below are given with the prompt `You are a MongoDB assistant.` and the user's prompt. Ping me if you'd like the full log and judge notes. This will lead have bias in the no skill vs skill results - oftentimes without the skill it will deduce the result and not show the query ran to the user. It should give an indicator if these changes have any impact.

<details>
<summary><b>Eval results (before)</b></summary>

📊 SUMMARY

| # | Eval Name                          | With Skill | Without Skill | Delta  |
|---|-------------------------------------|------------|---------------|--------|
|  1 | simple-find                         |        70% |           75% |    -5% |
|  2 | geo-based-find                      |       100% |           40% |   +60% |
|  3 | find-with-nested-match              |        85% |           10% |   +75% |
|  4 | find-translates-to-agg-mode-count   |       100% |           20% |   +80% |
|  5 | find-translates-to-agg-total-sum    |       100% |          100% |     0% |
|  6 | find-translates-to-agg-max-host     |       100% |           80% |   +20% |
|  7 | relative-date-find-last-year        |        90% |           10% |   +80% |
|  8 | relative-date-find-30-years-ago     |        85% |           10% |   +75% |
|  9 | number-field-find                   |       100% |           90% |   +10% |
| 10 | find-with-complex-projection        |       100% |           30% |   +70% |
| 11 | find-with-and-operator              |       100% |           40% |   +60% |
| 12 | find-with-non-english               |        85% |           65% |   +20% |
| 13 | find-with-regex-string-ops          |        95% |          100% |    -5% |
| 14 | find-simple-projection              |        90% |            0% |   +90% |
| 15 | basic-aggregate                     |        90% |            0% |   +90% |
| 16 | agg-filter-and-projection           |        30% |            0% |   +30% |
| 17 | geo-based-agg                       |       100% |          100% |     0% |
| 18 | agg-nested-fields-match             |        10% |           10% |     0% |
| 19 | agg-group-sort-limit-project        |        70% |           10% |   +60% |
| 20 | agg-group-sort-limit-project-2      |        30% |           20% |   +10% |
| 21 | relative-date-agg-30-years          |       100% |           85% |   +15% |
| 22 | relative-date-agg-last-year         |        90% |           70% |   +20% |
| 23 | agg-array-slice                     |        90% |            0% |   +90% |
| 24 | agg-multiple-conditions-match       |       100% |          100% |     0% |
| 25 | agg-non-english                     |       100% |           95% |    +5% |
| 26 | agg-simple-sort-limit               |       100% |          100% |     0% |
| 27 | agg-unwind-group                    |       100% |          100% |     0% |
| 28 | agg-size-operator                   |        85% |           75% |   +10% |
| 29 | agg-complex-word-frequency          |        95% |           82% |   +13% |
| 30 | agg-super-complex-percentage        |       100% |           90% |   +10% |
| 31 | agg-complex-regex-string-ops        |       100% |          100% |     0% |
| 32 | agg-join-lookup                     |       100% |          100% |     0% |
| 33 | agg-simple-projection               |        85% |           10% |   +75% |
| 34 | no-redundant-exists-with-comparison |        90% |            0% |   +90% |
| 35 | max-time-ms-option-used             |        90% |           20% |   +70% |
| 36 | find-in-java                        |       100% |          100% |     0% |

| Metric       | With Skill | Without Skill | Delta  |
|--------------|------------|---------------|--------|
| Avg Score    | 87.6% | 53.8%        | 33.8%  |
| Total Cost   | $2.7623 | $2.9056      | $-0.1433|
| Total Time   | 1023.1s | 1260.9s      | -237.8s|

Total cost (including judging): $6.8234

Skill wins: 25 | Losses: 2 | Ties: 9

</details>

<details>
<summary><b>Eval results (with changes)</b></summary>

📊 SUMMARY

| # | Eval Name                          | With Skill | Without Skill | Delta  |
|---|-------------------------------------|------------|---------------|--------|
|  1 | simple-find                         |       100% |           50% |   +50% |
|  2 | geo-based-find                      |        90% |           90% |     0% |
|  3 | find-with-nested-match              |        90% |           10% |   +80% |
|  4 | find-translates-to-agg-mode-count   |       100% |           10% |   +90% |
|  5 | find-translates-to-agg-total-sum    |       100% |           40% |   +60% |
|  6 | find-translates-to-agg-max-host     |       100% |           60% |   +40% |
|  7 | relative-date-find-last-year        |        70% |           10% |   +60% |
|  8 | relative-date-find-30-years-ago     |         0% |           10% |   -10% |
|  9 | number-field-find                   |       100% |          100% |     0% |
| 10 | find-with-complex-projection        |       100% |           85% |   +15% |
| 11 | find-with-and-operator              |       100% |           20% |   +80% |
| 12 | find-with-non-english               |       100% |          100% |     0% |
| 13 | find-with-regex-string-ops          |        85% |           85% |     0% |
| 14 | find-simple-projection              |       100% |            0% |  +100% |
| 15 | basic-aggregate                     |        90% |            0% |   +90% |
| 16 | agg-filter-and-projection           |        30% |            0% |   +30% |
| 17 | geo-based-agg                       |       100% |          100% |     0% |
| 18 | agg-nested-fields-match             |        85% |           50% |   +35% |
| 19 | agg-group-sort-limit-project        |        70% |           10% |   +60% |
| 20 | agg-group-sort-limit-project-2      |       100% |           20% |   +80% |
| 21 | relative-date-agg-30-years          |        95% |          100% |    -5% |
| 22 | relative-date-agg-last-year         |        85% |            0% |   +85% |
| 23 | agg-array-slice                     |       100% |           10% |   +90% |
| 24 | agg-multiple-conditions-match       |       100% |          100% |     0% |
| 25 | agg-non-english                     |       100% |          100% |     0% |
| 26 | agg-simple-sort-limit               |       100% |          100% |     0% |
| 27 | agg-unwind-group                    |       100% |          100% |     0% |
| 28 | agg-size-operator                   |       100% |           90% |   +10% |
| 29 | agg-complex-word-frequency          |        95% |           30% |   +65% |
| 30 | agg-super-complex-percentage        |       100% |           85% |   +15% |
| 31 | agg-complex-regex-string-ops        |       100% |          100% |     0% |
| 32 | agg-join-lookup                     |       100% |          100% |     0% |
| 33 | agg-simple-projection               |        90% |            0% |   +90% |
| 34 | no-redundant-exists-with-comparison |        90% |            0% |   +90% |
| 35 | max-time-ms-option-used             |        85% |           30% |   +55% |
| 36 | find-in-java                        |       100% |          100% |     0% |

| Metric       | With Skill | Without Skill | Delta  |
|--------------|------------|---------------|--------|
| Avg Score    | 90.3% | 52.6%        | 37.6%  |
| Total Cost   | $2.8551 | $2.5615      | $0.2937|
| Total Time   | 1395.2s | 1007.6s      | 387.6s |

Total cost (including judging): $6.4988

Skill wins: 22 | Losses: 2 | Ties: 12

</details>
