### PR TITLE
feat: add codex plugin support MCP-479

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+    "name": "mongodb-agent-skills",
+    "interface": {
+        "displayName": "MongoDB Agent Skills"
+    },
+    "plugins": [
+        {
+            "name": "mongodb",
+            "source": {
+                "source": "url",
+                "url": "https://github.com/mongodb/agent-skills.git",
+                "ref": "main"
+            },
+            "policy": {
+                "installation": "AVAILABLE",
+                "authentication": "ON_INSTALL"
+            },
+            "category": "Databases"
+        }
+    ]
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+    "name": "mongodb",
+    "version": "1.1.0",
+    "description": "Official Codex plugin for MongoDB (MCP Server + Skills). Connect to databases, explore data, manage collections, optimize queries, generate reliable code, implement best practices, develop advanced features, and more.",
+    "author": {
+        "name": "MongoDB",
+        "email": "agent-plugins@mongodb.com",
+        "url": "https://www.mongodb.com"
+    },
+    "homepage": "https://www.mongodb.com/docs/codex/",
+    "repository": "https://github.com/mongodb/agent-skills",
+    "license": "Apache-2.0",
+    "keywords": [
+        "mongodb",
+        "database",
+        "mcp",
+        "vector-search"
+    ],
+    "skills": "./skills/",
+    "mcpServers": "./mcp.json",
+    "interface": {
+        "displayName": "MongoDB",
+        "shortDescription": "Official MongoDB plugin: MCP server, skills, and best practices for database workflows.",
+        "longDescription": "The official MongoDB plugin bundles the MongoDB MCP server and a curated set of agent skills covering query writing, query optimization, schema design, Atlas Search and Vector Search, connection best practices, and Atlas Stream Processing. It gives your agent the tools and knowledge to connect to any MongoDB deployment, explore data, generate reliable code, and implement MongoDB best practices end to end.",
+        "developerName": "MongoDB",
+        "category": "Databases",
+        "capabilities": ["Read", "Write"],
+        "websiteURL": "https://www.mongodb.com",
+        "privacyPolicyURL": "https://www.mongodb.com/legal/privacy/privacy-policy",
+        "defaultPrompt": [
+            "Set up my MongoDB connection using the mongodb-mcp-setup skill.",
+            "Connect to my MongoDB database and explore its collections.",
+            "Write a MongoDB aggregation pipeline to analyze my data.",
+            "Optimize the slow queries in my MongoDB deployment.",
+            "Design a MongoDB schema for my use case."
+        ],
+        "logo": "./assets/logo.png",
+        "brandColor": "#00ED64"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ Install the plugin from the [Cursor marketplace](https://cursor.com/marketplace/
 
 2. Follow the prompts to complete the installation.
 
+### Codex
+
+Install the plugin by running the following command from a Codex session:
+
+```bash
+codex plugin marketplace add mongodb/agent-skills
+```
+
+Follow the prompts to complete the installation.
+
 ### Gemini
 
 Install the extension from the [Gemini marketplace](https://geminicli.com/extensions/?name=mongodbagent-skills), or run the following command from Gemini CLI:

--- a/skills/mongodb-mcp-setup/SKILL.md
+++ b/skills/mongodb-mcp-setup/SKILL.md
@@ -26,29 +26,50 @@ The MongoDB MCP server requires authentication. Users have three options:
    - Runs Atlas locally in Docker, requires Docker installed
    - No credentials or cloud cluster access
 
-This is an interactive step-by-step guide. The agent detects the user's environment and provides tailored instructions, but **never asks for or handles credentials** — users add those directly to their shell profile in Step 5. Make this clear to the user whenever credentials come up in Steps 3a and 3b.
+This is an interactive step-by-step guide. The agent detects the user's environment and provides tailored instructions, but **never asks for or handles credentials** — users add those directly to their shell profile or agentic client config in Step 5. Make this clear to the user whenever credentials come up in Steps 3a and 3b.
+
+## Step 0: Detect Client
+
+Before anything else, determine which agentic client the user is running. This controls how credentials are configured in Step 1 and Step 5.
+
+Run:
+
+```bash
+env | grep "^CODEX_"
+```
+
+- **If no `CODEX_*` variables are present** → the user is running a **shell-based client** (Claude, Cursor, Gemini CLI, Copilot CLI, etc.). Credentials are configured via shell profile environment variables.
+- **If any `CODEX_*` variables are present** → the user is running **Codex**. Credentials are stored in `~/.codex/config.toml` (macOS/Linux) or `%USERPROFILE%\.codex\config.toml` (Windows), not in shell environment variables. The desktop app does not inherit shell env vars when launched from Finder, Launchpad, or the Windows Start menu.
+
+Carry this **client type** (Codex vs. shell-based) forward through every subsequent step.
 
 ## Step 1: Check Existing Configuration
 
-Before starting the setup, check if the user already has the required environment variables configured.
+Check whether credentials are already configured.
 
-Run this command to check for existing configuration (masking values to avoid exposing credentials):
+**For shell-based clients** — check the current environment:
 
 ```bash
 env | grep "^MDB_MCP" | sed '/^MDB_MCP_READ_ONLY=/!s/=.*/=[set]/'
 ```
 
-**Interpretation:**
+**For Codex** — search `~/.codex/config.toml` (macOS/Linux) or `%USERPROFILE%\.codex\config.toml` (Windows):
 
-- If `MDB_MCP_CONNECTION_STRING` is set → connection string auth is configured
-- If both `MDB_MCP_API_CLIENT_ID` and `MDB_MCP_API_CLIENT_SECRET` are set → service account auth is configured. If only one is set, treat it as incomplete.
-- If `MDB_MCP_READ_ONLY=true` → read-only mode is enabled
+```bash
+grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml 2>/dev/null | sed '/MDB_MCP_READ_ONLY/!s/ = .*/ = "[set]"/'
+```
+
+**Interpretation (both):**
+
+- If `MDB_MCP_CONNECTION_STRING` appears → connection string auth is configured
+- If both `MDB_MCP_API_CLIENT_ID` and `MDB_MCP_API_CLIENT_SECRET` appear → service account auth is configured. If only one is present, treat it as incomplete.
+- If `MDB_MCP_READ_ONLY` appears → read-only mode is enabled
 
 **Partial Configuration Handling:**
 
-- User wants to add read-only to existing setup (has auth, no `MDB_MCP_READ_ONLY`) → skip to Step 4
-- User wants to switch authentication methods → explain they should remove the old variables from their shell profile first, then proceed with Steps 2–5
-- User wants to update credentials → skip to Step 5 (profile editing instructions)
+- User wants to add read-only to existing setup (has auth, no read-only flag) → skip to Step 4
+- User wants to switch authentication methods → explain they should remove the old credentials first (from `config.toml` for Codex, from their shell profile for shell-based clients), then proceed with Steps 2–5
+- User wants to update credentials → skip to Step 5
 
 **Important**: If the user wants an Atlas Admin API action (managing clusters, creating users, performance advisor) but only has `MDB_MCP_CONNECTION_STRING`, explain they need service account credentials and offer to walk through setup.
 
@@ -174,83 +195,91 @@ Ask whether they want read-only or read-write access:
 - **Read-Only**: Data reads only, no modifications
   - Best for: Production data safety, reporting, compliance
 
-**If read-only**: include `export MDB_MCP_READ_ONLY="true"` in the profile snippet in Step 5.
-**If read-write**: omit `MDB_MCP_READ_ONLY` (defaults to read-write).
+**If read-only**: include the read-only flag in the credential snippet in Step 5.
+**If read-write**: omit it (defaults to read-write).
 
-Proceed to Step 5 (Update Shell Profile).
+Proceed to Step 5 (Configure Credentials).
 
-## Step 5: Update Shell Profile
+## Step 5: Configure Credentials
 
-Help the user add the environment variables to their shell profile. **Do not ask for or handle credentials** — provide exact instructions so the user can add them directly.
+**Do not ask for or handle credentials** — provide exact instructions so the user can add them directly.
 
-### 5.1: Detect Shell and Profile File
+### 5.1: Add credentials
 
-If the user is on Windows, assume **PowerShell** but ask the user to confirm. For Unix/macOS, detect the shell to determine the correct profile file by running:
+**For shell-based clients** — store credentials in a dedicated `~/.mcp-env` file (not directly in the shell profile), then source it from the profile. This keeps credentials out of files that are often group/world readable by default and prevents accidentally committing them to git.
 
-```bash
-echo $SHELL
-```
+**For Codex** — add to `~/.codex/config.toml` (macOS/Linux) or `%USERPROFILE%\.codex\config.toml` (Windows).
 
-Based on the result, identify the appropriate profile file using your training data. If unsure which shell or profile they are using, ask them to specify the path.
-
-### 5.2: Show the Exact Snippet to Add
-
-Tell the user to store credentials in a dedicated `~/.mcp-env` file (not directly in their shell profile). This keeps credentials out of files that are often group/world readable by default and prevents accidentally committing them to git. Make sure to adapt the path in the instructions to be in the same folder as the shell profile file.
-
-**Step 1**: Create/edit `~/.mcp-env` (e.g. `nano ~/.mcp-env`) and add:
+Show the user the appropriate snippet:
 
 **For Connection String (Option A):**
 
+Shell-based clients (`~/.mcp-env`):
+
 ```bash
-# MongoDB MCP Server Configuration
 export MDB_MCP_CONNECTION_STRING="<paste-your-connection-string-here>"
+```
+
+Codex (`config.toml`):
+
+```toml
+[mcp_servers.mongodb.env]
+MDB_MCP_CONNECTION_STRING = "<paste-your-connection-string-here>"
 ```
 
 **For Service Account (Option B):**
 
+Shell-based clients (`~/.mcp-env`):
+
 ```bash
-# MongoDB MCP Server Configuration (Atlas Service Account)
 export MDB_MCP_API_CLIENT_ID="<paste-your-client-id-here>"
 export MDB_MCP_API_CLIENT_SECRET="<paste-your-client-secret-here>"
 ```
 
+Codex (`config.toml`):
+
+```toml
+[mcp_servers.mongodb.env]
+MDB_MCP_API_CLIENT_ID = "<paste-your-client-id-here>"
+MDB_MCP_API_CLIENT_SECRET = "<paste-your-client-secret-here>"
+```
+
 **If read-only was chosen (Step 4), also add:**
 
+Shell-based: `export MDB_MCP_READ_ONLY="true"` in `~/.mcp-env`.
+
+Codex: `MDB_MCP_READ_ONLY = "true"` under the same `[mcp_servers.mongodb.env]` section.
+
+⚠️ Both `config.toml` and `~/.mcp-env` are stored in plaintext. Do not commit them to version control.
+
+### 5.2: Finalize (shell-based clients only)
+
+Restrict permissions on `~/.mcp-env`:
+
 ```bash
-export MDB_MCP_READ_ONLY="true"
+chmod 600 ~/.mcp-env
 ```
 
-**Step 2**: Restrict permissions on the file so only the owner can read it:
+Add `source ~/.mcp-env` to the shell profile (e.g. `~/.zshrc`). Adjust for the detected shell (e.g. for fish: `bass source ~/.mcp-env` or `set -x`; for PowerShell: dot-source a `.ps1` file instead).
+
+Detect the shell and profile file by running `echo $SHELL` if needed.
+
+### 5.3: Verify
+
+**Shell-based clients** — reload the profile first, then verify:
 
 ```bash
-chmod 600 ~/.mcp-env # adapt command for Windows if needed
-```
-
-**Step 3**: Source the file from the shell profile. Tell the user to open their profile file (e.g. `code ~/.zshrc`, `nano ~/.zshrc`) and add this line:
-
-```bash
-source ~/.mcp-env
-```
-
-Adjust syntax for the detected shell (e.g. for fish: `bass source ~/.mcp-env` or set variables directly with `set -x`; for PowerShell: dot-source a `.ps1` file instead).
-
-### 5.3: After Editing — Reload and Verify
-
-Once the user has saved the file, provide the commands to reload and verify:
-
-**Reload the profile:**
-
-```bash
-source ~/.zshrc   # adjust path to match their profile file
-```
-
-**Verify the variables are set (masking values to avoid exposing credentials):**
-
-```bash
+source ~/.zshrc  # adjust to match the profile file
 env | grep "^MDB_MCP" | sed '/^MDB_MCP_READ_ONLY=/!s/=.*/=[set]/'
 ```
 
-Expected output should show the variable name(s) they just added, each with `=[set]`. If nothing appears, check that `source ~/.mcp-env` is in the profile file, the profile was reloaded, and `~/.mcp-env` was saved.
+**Codex:**
+
+```bash
+grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml | sed '/MDB_MCP_READ_ONLY/!s/ = .*/ = "[set]"/'
+```
+
+Expected output shows the configured key(s) with values redacted to `[set]`. If nothing appears, check that credentials were saved and (for shell-based clients) that the profile was reloaded.
 
 Proceed to Step 6 (Next Steps).
 
@@ -258,7 +287,9 @@ Proceed to Step 6 (Next Steps).
 
 ### For Options A & B (Connection String / Service Account):
 
-1. **Restart the agentic client**: Fully quit the client, then in your terminal run `source <profile-file>` (e.g. `source ~/.zshrc`, adjust command and path based on the user shell) to load the new variables into the current shell session. Open the client from that same shell session so it inherits the environment.
+1. **Restart the agentic client**:
+   - **Shell-based clients**: Fully quit the client, then run `source <profile-file>` to load the new variables, and reopen the client from that same terminal session so it inherits the environment.
+   - **Codex**: Fully quit and relaunch the app. No terminal session needed — credentials come from `config.toml`.
 
 2. **Verify MCP Server**: After restart, test by performing a MongoDB operation.
 
@@ -278,9 +309,10 @@ Proceed to Step 6 (Next Steps).
 
 ## Troubleshooting
 
-- **Variables not appearing after `source`**: Check the profile file path and confirm the file was saved
+- **Variables not appearing after `source`** (shell-based clients): Check the profile file path and confirm the file was saved
 - **Client doesn't pick up variables**: Ensure full restart (quit + reopen), not just a reload
+- **Codex desktop app not picking up credentials**: If launched from Finder, Launchpad, or the Windows Start menu, Codex does not inherit shell environment variables from `.zshrc`/`.zprofile`/PowerShell profiles. Use `~/.codex/config.toml` (macOS/Linux) or `%USERPROFILE%\.codex\config.toml` (Windows) instead (see Step 5)
 - **Invalid connection string format**: Re-check the format; must start with `mongodb://` or `mongodb+srv://`
 - **Atlas Admin API errors (Option B)**: Verify your IP is in the service account's API Access List
-- **Read-only mode not working**: Check `MDB_MCP_READ_ONLY=true` is set — run `env | grep ^MDB_MCP_READ_ONLY`
+- **Read-only mode not working**: Check that `MDB_MCP_READ_ONLY` is set — in `config.toml` under `[mcp_servers.mongodb.env]` for Codex, or via `env | grep ^MDB_MCP_READ_ONLY` for shell-based clients
 - **fish/PowerShell**: Syntax differs — use `set -x` (fish) or `$env:` (PowerShell) instead of `export`

--- a/skills/mongodb-mcp-setup/SKILL.md
+++ b/skills/mongodb-mcp-setup/SKILL.md
@@ -56,7 +56,7 @@ env | grep "^MDB_MCP" | sed '/^MDB_MCP_READ_ONLY=/!s/=.*/=[set]/'
 **For Codex** — search `~/.codex/config.toml` (macOS/Linux) or `%USERPROFILE%\.codex\config.toml` (Windows):
 
 ```bash
-grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml 2>/dev/null | sed '/MDB_MCP_READ_ONLY/!s/ = .*/ = "[set]"/'
+grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml 2>/dev/null | sed '/MDB_MCP_READ_ONLY/!s/[[:space:]]*=[[:space:]].*/ = "[set]"/'
 ```
 
 **Interpretation (both):**
@@ -257,6 +257,7 @@ Codex: `MDB_MCP_READ_ONLY = "true"` under the same `[mcp_servers.mongodb.env]` s
 Restrict permissions on `~/.mcp-env`:
 
 ```bash
+# adjust for windows if needed
 chmod 600 ~/.mcp-env
 ```
 
@@ -276,7 +277,8 @@ env | grep "^MDB_MCP" | sed '/^MDB_MCP_READ_ONLY=/!s/=.*/=[set]/'
 **Codex:**
 
 ```bash
-grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml | sed '/MDB_MCP_READ_ONLY/!s/ = .*/ = "[set]"/'
+# adjust path if on Windows
+grep -E 'MDB_MCP_(CONNECTION_STRING|API_CLIENT_ID|API_CLIENT_SECRET|READ_ONLY)' ~/.codex/config.toml 2>/dev/null | sed '/MDB_MCP_READ_ONLY/!s/[[:space:]]*=[[:space:]].*/ = "[set]"/'
 ```
 
 Expected output shows the configured key(s) with values redacted to `[set]`. If nothing appears, check that credentials were saved and (for shell-based clients) that the profile was reloaded.


### PR DESCRIPTION
Adds support for Codex (both cli and desktop app) and adjusts the mcp setup skill to handle the Codex specifics.