### PR TITLE
chore: fixup the install instructions for Codex MCP-479

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,19 @@ Install the plugin from the [Cursor marketplace](https://cursor.com/marketplace/
 
 ### Codex
 
-Install the plugin by running the following command from a Codex session:
+1. Install the plugin by running the following command from a Codex session:
 
-```bash
-codex plugin marketplace add mongodb/agent-skills
-```
+   ```bash
+   codex plugin marketplace add mongodb/agent-skills
+   ```
 
-Follow the prompts to complete the installation.
+2. Start Codex and open the plugins browser:
+
+   ```bash
+   /plugins
+   ```
+
+3. Navigate to the "MongoDB Agent Skills" tab and install the `mongodb` plugin.
 
 ### Gemini
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Install the plugin from the [Cursor marketplace](https://cursor.com/marketplace/
 
 ### Codex
 
-1. Install the plugin by running the following command from a Codex session:
+1. Add the mongodb/agent-skills marketplace to Codex:
 
    ```bash
    codex plugin marketplace add mongodb/agent-skills


### PR DESCRIPTION
The old instructions were imprecise/overly simplistic, so cleaned them up and added more detailed steps.