### PR TITLE
fix: update Atlas service account navigation steps

### DIFF
--- a/skills/mongodb-mcp-setup/SKILL.md
+++ b/skills/mongodb-mcp-setup/SKILL.md
@@ -137,9 +137,10 @@ Direct the user to create a MongoDB Atlas Service Account:
 Walk them through the key steps:
 
 1. **Navigate to MongoDB Atlas** — [cloud.mongodb.com](https://cloud.mongodb.com)
-2. **Go to Access Manager** → **Service Accounts** → **Create Service Account**
-3. **Set Permissions** — Grant Organization Member or Project Owner (see docs for exact permission mappings)
-4. **Generate Credentials** — Create Client ID and Secret
+2. **Select your organization** from the ORGANIZATION section near the top of the page
+3. **Go to "Project Identity and Access"** on the left sidebar → **Applications** → **Create Service Account**
+4. **Set Permissions** — Grant Organization Member or Project Owner (see docs for exact permission mappings)
+5. **Generate Credentials** — Create Client ID and Secret
    - ⚠️ The **Client Secret is shown only once** — save it immediately before leaving the page
 5. **Note both values** — you'll need Client ID and Client Secret for Step 5
 


### PR DESCRIPTION
Hi there ! Trying out the PR flow - here is a correction for the UI path for creating a service account. Select org first, then use Project Identity and Access > Applications instead of Access Manager (which isn't in UI).

# MongoDB Agent Skill Submission

## Skill Information

**Skill Name:** mongodb-mcp-setup
**Skill Directory:** `skills/`

## Use Case

<!-- Describe what use case this skill addresses. What problem does it solve for MongoDB users? --> Setting up MCP-Server -- getting service account credentials.


## Value Proposition

<!-- Explain why this skill is valuable for MongoDB users. What makes it useful? --> Accurate set up steps 

## Special Considerations

<!-- List any special considerations or prerequisites for using this skill (e.g., required MongoDB version, specific configurations, dependencies, etc.). If none, write "None". --> None


## Validation Prompts

<!-- Provide the five prompts you used to validate your skill's effectiveness with LLMs. -->

1."I just installed the MongoDB MCP server - set it up"

2. "How do I create a service account for the MongoDB MCP server?"

3. "help me set up the mongodb MCP"

4. "I want read-only access to my MongoDB cluster via the MCP server.. how do I configure that?"

5. "I set up the MongoDB MCP server but it's still not working.. the variables don't seem to be loading."

## Author Self-Validation

<!-- Confirm you have used the `review-skill` skill to perform a self-review of this skill. -->

- [X] Ran `review-skill` skill to self-review structure, format, content quality, and novelty
- [X ] Tested skill with LLMs using the five prompts above

## SME Review

<!-- Once CI passes and you've addressed any LLM feedback, tag the appropriate SME for review -->

**SME:** @<!-- username -->

## Additional Context

<!-- Add any other context that would help reviewers evaluate this skill efficiently -->
