### PR TITLE
chore: add explicit permissions to validate-skills workflow

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,6 +5,9 @@ on:
     paths:
       - "skills/**"
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Add a top-level `permissions: contents: read` block to `.github/workflows/validate-skills.yml`
- Resolves [code scanning alert #1](https://github.com/mongodb/agent-skills/security/code-scanning/1) (`actions/missing-workflow-permissions`, medium severity)

## Context

The validate-skills workflow only checks out the repo and runs read-only validation against the `skills/` directory — it doesn't write comments, push code, or call any GitHub API that requires elevated permissions. `contents: read` is the minimum needed for `actions/checkout` to work.

The other three workflows (`codeql.yml`, `draft-release.yml`, `prepare-release.yml`) already have explicit permissions blocks, so this is the last one outstanding.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, confirm code scanning alert #1 is closed automatically