### PR TITLE
Bump skill-gate to v0.1.1

### DIFF
--- a/.github/workflows/skill-gate.yml
+++ b/.github/workflows/skill-gate.yml
@@ -140,7 +140,7 @@ jobs:
       - name: Install skill-gate (pinned)
         # Mirrors the existing `go install …skill-validator@…` step.
         if: steps.changed.outputs.count != '0'
-        run: go install github.com/mongodb/skill-gate/cmd/skill-gate@v0.1.0
+        run: go install github.com/mongodb/skill-gate/cmd/skill-gate@v0.1.1
 
       - name: Run skill-gate (complete scan — static + LLM judge)
         id: scan


### PR DESCRIPTION
## Summary

- Update the skill-gate workflow from `v0.1.0` to the released `v0.1.1`.
- v0.1.1 includes symlink rejection and no-follow file handling for PR-controlled skill content.

## Release

- skill-gate tag: `v0.1.1`
- Release commit: `1298dc3`

This keeps the workflow pinned to an immutable release tag.
