### PR TITLE
chore: narrow default CODEOWNERS to @mongodb/devdocs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # CODEOWNERS file for agent-skills repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @mongodb/dbx-devtools @mongodb/apix-devtools @mongodb/devdocs
+* @mongodb/devdocs
 
 # GitHub configuration and workflows
 /.github/ @mongodb/dbx-devtools @mongodb/apix-devtools @mongodb/devdocs


### PR DESCRIPTION
Summary                                                                         
  - Remove @mongodb/dbx-devtools and @mongodb/apix-devtools from the catch-all `*`
  rule, leaving only @mongodb/devdocs as the default owner for non-.github paths.    
  - The /.github/ rule is unchanged (still all three teams).                         